### PR TITLE
add temporary files to gitignore. allow for partial BeautifulSoup Tag…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 mf2py.egg-info/
 nbproject/
 venv/
+*~

--- a/mf2py/parser.py
+++ b/mf2py/parser.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from __future__ import unicode_literals, print_function
 from bs4 import BeautifulSoup
+from bs4.element import Tag
 from mf2py import backcompat, mf2_classes, implied_properties, parse_property
 from mf2py import temp_fixes
 from mf2py.dom_helpers import get_attr
@@ -58,7 +59,7 @@ class Parser(object):
 
         if doc:
             self.__doc__ = doc
-            if not isinstance(self.__doc__, BeautifulSoup):
+            if not ( isinstance(self.__doc__, BeautifulSoup) or isinstance(self.__doc__, Tag) ):
                 self.__doc__ = BeautifulSoup(self.__doc__)
 
         if url:


### PR DESCRIPTION
Allow for partial tags in self.__doc__ . Useful for parsing after a BeautifulSoup document was searched for partial elements, e.g. finding top-level h-feed or h-entry and only parsing those for microformats.

cc: @kylewm