### PR TITLE
replace calls to find_all with custom traversal

### DIFF
--- a/mf2py/backcompat.py
+++ b/mf2py/backcompat.py
@@ -4,6 +4,7 @@ microformats2 names. Ported and adapted from php-mf2.
 """
 
 from __future__ import unicode_literals, print_function
+from .dom_helpers import get_descendents
 import bs4
 
 import sys
@@ -238,13 +239,11 @@ def apply_rules(doc):
                        for cls in child.get('class', [])):
                 apply_rules_to_children(child, rules)
 
-    def has_classic_root(el):
-        return any(cls in CLASSIC_ROOT_MAP for cls in el.get('class', []))
-
-    for el in doc.find_all(has_classic_root):
-        for old_root in el.get('class', []):
-            if old_root in CLASSIC_ROOT_MAP:
-                new_root = CLASSIC_ROOT_MAP[old_root]
-                if new_root not in el.get('class', []):
-                    el['class'].append(new_root)
-                    apply_rules_to_children(el, RULES.get(old_root, []))
+    for el in get_descendents(doc):
+        if any(cls in CLASSIC_ROOT_MAP for cls in el.get('class', [])):
+            for old_root in el.get('class', []):
+                if old_root in CLASSIC_ROOT_MAP:
+                    new_root = CLASSIC_ROOT_MAP[old_root]
+                    if new_root not in el.get('class', []):
+                        el['class'].append(new_root)
+                        apply_rules_to_children(el, RULES.get(old_root, []))

--- a/mf2py/dom_helpers.py
+++ b/mf2py/dom_helpers.py
@@ -1,4 +1,6 @@
 import sys
+import bs4
+
 if sys.version < '3':
     text_type = unicode
     binary_type = str
@@ -26,3 +28,16 @@ def get_attr(el, attr, check_name=None):
         return el.get(attr)
     if isinstance(check_name, (tuple, list)) and el.name in check_name:
         return el.get(attr)
+
+
+def get_children(node):
+    """An iterator over the immediate children tags of this tag"""
+    for child in node.contents:
+        if isinstance(child, bs4.Tag):
+            yield child
+
+def get_descendents(node):
+    for child in get_children(node):
+        yield child
+        for desc in get_descendents(child):
+            yield desc

--- a/mf2py/implied_properties.py
+++ b/mf2py/implied_properties.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals, print_function
 from . import mf2_classes
-from .dom_helpers import get_attr
+from .dom_helpers import get_attr, get_children
 import sys
 
 if sys.version < '3':
@@ -29,7 +29,7 @@ def name(el):
         return [prop_value]
 
     # if only one child
-    children = el.find_all(True, recursive=False)
+    children = list(get_children(el))
     if len(children) == 1:
         # use alt if child is img
         prop_value = get_attr(children[0], "alt", check_name="img")
@@ -41,7 +41,7 @@ def name(el):
         if prop_value is not None:
             return [prop_value]
 
-        grandchildren = children[0].find_all(True, recursive=False)
+        grandchildren = list(get_children(children[0]))
         # if only one grandchild
         if len(grandchildren) == 1:
             # use alt if grandchild is img
@@ -80,7 +80,7 @@ def photo(el, base_url=''):
 
     # if element has one image child use source if exists and img is
     # not root class
-    poss_imgs = el.find_all("img", recursive=False)
+    poss_imgs = [c for c in get_children(el) if c.name == 'img']
     if len(poss_imgs) == 1:
         poss_img = poss_imgs[0]
         if mf2_classes.root(poss_img.get('class', [])) == []:
@@ -90,7 +90,7 @@ def photo(el, base_url=''):
 
     # if element has one object child use data if exists and object is
     # not root class
-    poss_objs = el.find_all("object", recursive=False)
+    poss_objs = [c for c in get_children(el) if c.name == 'object']
     if len(poss_objs) == 1:
         poss_obj = poss_objs[0]
         if mf2_classes.root(poss_obj.get('class', [])) == []:
@@ -98,12 +98,12 @@ def photo(el, base_url=''):
             if prop_value is not None:
                 return [prop_value]
 
-    children = el.find_all(True, recursive=False)
+    children = list(get_children(el))
     # if only one child then repeat above in child
     if len(children) == 1:
         # if element has one image child use source if exists and img
         # is not root class
-        poss_imgs = children[0].find_all("img", recursive=False)
+        poss_imgs = [c for c in get_children(children[0]) if c.name == 'img']
         if len(poss_imgs) == 1:
             poss_img = poss_imgs[0]
             if mf2_classes.root(poss_img.get('class', [])) == []:
@@ -113,7 +113,7 @@ def photo(el, base_url=''):
 
         # if element has one object child use data if exists and
         # object is not root class
-        poss_objs = children[0].find_all("object", recursive=False)
+        poss_objs = [c for c in get_children(children[0]) if c.name == 'object']
         if len(poss_objs) == 1:
             poss_obj = poss_objs[0]
             if mf2_classes.root(poss_obj.get('class', [])) == []:
@@ -138,7 +138,7 @@ def url(el, base_url=''):
         return [urljoin(base_url, prop_value)]
 
     # if one link child use its href
-    poss_as = el.find_all("a", recursive=False)
+    poss_as = [c for c in get_children(el) if c.name == 'a']
     if len(poss_as) == 1:
         poss_a = poss_as[0]
         if mf2_classes.root(poss_a.get('class', [])) == []:

--- a/mf2py/parse_property.py
+++ b/mf2py/parse_property.py
@@ -1,7 +1,7 @@
 """functions to parse the properties of elements"""
 from __future__ import unicode_literals, print_function
 
-from .dom_helpers import get_attr
+from .dom_helpers import get_attr, get_children, get_descendents
 import sys
 import re
 
@@ -23,20 +23,20 @@ TIME_RE = r'(?P<rawtime>%s)( ?(?P<ampm>%s))?( ?(?P<tz>%s))?' % (RAWTIME_RE, AMPM
 DATETIME_RE = r'(?P<date>%s)(?P<separator>[T ])(?P<time>%s)' % (DATE_RE, TIME_RE)
 
 
-def is_vcp_class(c):
-    return c == 'value' or c == 'value-title'
-
-
 def get_vcp_value(el):
     if 'value-title' in el.get('class', []):
         return el.get('title')
     return el.get_text()
 
 
+def get_vcp_children(el):
+    return [c for c in get_children(el) if c.has_attr('class')
+            and ('value' in c['class'] or 'value-title' in c['class'])]
+
 def text(el):
     """Process p-* properties"""
     # handle value-class-pattern
-    value_els = el.find_all(class_=is_vcp_class, recursive=False)
+    value_els = get_vcp_children(el)
     if value_els:
         return ''.join(get_vcp_value(el) for el in value_els)
 
@@ -71,7 +71,7 @@ def url(el, base_url=''):
     if prop_value is not None:
         return urljoin(base_url, prop_value)
 
-    value_els = el.find_all(class_=is_vcp_class, recursive=False)
+    value_els = get_vcp_children(el)
     if value_els:
         return urljoin(base_url, ''.join(get_vcp_value(el) for el in value_els))
 
@@ -123,7 +123,7 @@ def datetime(el, default_date=None):
         return dtstr
 
     # handle value-class-pattern
-    value_els = el.find_all(class_=is_vcp_class)
+    value_els = get_vcp_children(el)
     if value_els:
         date_parts = []
         for value_el in value_els:

--- a/mf2py/temp_fixes.py
+++ b/mf2py/temp_fixes.py
@@ -1,3 +1,6 @@
+from .dom_helpers import get_descendents
+
 def apply_rules(doc):
-    for el in doc.find_all("template"):
-        el.extract()
+    for el in get_descendents(doc):
+        if el.name == 'template':
+            el.extract()


### PR DESCRIPTION
bs4.find and find_all seem to be unduly expensive operations.
just replacing them with naive get_children and get_descendants
calls cuts the *total* parse time in half for lots of documents.

Parsing kylewm.com went from around 130ms to 66ms 
(epeus.blogspot.com and chocolateandvodka.com -- backcompat
 tests -- are about the same), the very large page at 
rhiaro.co.uk/travel from 780ms to 420ms

Ref #63