### PR TITLE
implied properties should ignore alt=""

### DIFF
--- a/mf2py/implied_properties.py
+++ b/mf2py/implied_properties.py
@@ -18,14 +18,19 @@ def name(el):
     Returns:
       string: the implied name value
     """
+    def non_empty(val):
+        """If alt or title is empty, we don't want to use it as the implied
+        name"""
+        return val is not None and val != ''
+
     # if image use alt text if not empty
     prop_value = get_attr(el, "alt", check_name=("img", "area"))
-    if prop_value:
+    if non_empty(prop_value):
         return [prop_value]
 
     # if abbreviation use the title if not empty
     prop_value = get_attr(el, "title", check_name="abbr")
-    if prop_value:
+    if non_empty(prop_value):
         return [prop_value]
 
     # if only one child
@@ -33,12 +38,12 @@ def name(el):
     if len(children) == 1:
         # use alt if child is img
         prop_value = get_attr(children[0], "alt", check_name="img")
-        if prop_value:
+        if non_empty(prop_value):
             return [prop_value]
 
         # use title if child is abbr
         prop_value = get_attr(children[0], "title", check_name="abbr")
-        if prop_value:
+        if non_empty(prop_value):
             return [prop_value]
 
         grandchildren = list(get_children(children[0]))
@@ -46,12 +51,12 @@ def name(el):
         if len(grandchildren) == 1:
             # use alt if grandchild is img
             prop_value = get_attr(grandchildren[0], "alt", check_name="img")
-            if prop_value:
+            if non_empty(prop_value):
                 return [prop_value]
 
             # use title if grandchild is title
             prop_value = get_attr(grandchildren[0], "title", check_name="abbr")
-            if prop_value:
+            if non_empty(prop_value):
                 return [prop_value]
 
     # use text if all else fails
@@ -70,12 +75,12 @@ def photo(el, base_url=''):
     """
     # if element is an image use source if exists
     prop_value = get_attr(el, "src", check_name="img")
-    if prop_value:
+    if prop_value is not None:
         return [urljoin(base_url, prop_value)]
 
     # if element is an object use data if exists
     prop_value = get_attr(el, "data", check_name="object")
-    if prop_value:
+    if prop_value is not None:
         return [prop_value]
 
     # if element has one image child use source if exists and img is
@@ -85,7 +90,7 @@ def photo(el, base_url=''):
         poss_img = poss_imgs[0]
         if mf2_classes.root(poss_img.get('class', [])) == []:
             prop_value = get_attr(poss_img, "src", check_name="img")
-            if prop_value:
+            if prop_value is not None:
                 return [urljoin(base_url, prop_value)]
 
     # if element has one object child use data if exists and object is
@@ -95,7 +100,7 @@ def photo(el, base_url=''):
         poss_obj = poss_objs[0]
         if mf2_classes.root(poss_obj.get('class', [])) == []:
             prop_value = get_attr(poss_obj, "data", check_name="object")
-            if prop_value:
+            if prop_value is not None:
                 return [prop_value]
 
     children = list(get_children(el))
@@ -108,7 +113,7 @@ def photo(el, base_url=''):
             poss_img = poss_imgs[0]
             if mf2_classes.root(poss_img.get('class', [])) == []:
                 prop_value = get_attr(poss_img, "src", check_name="img")
-                if prop_value:
+                if prop_value is not None:
                     return [urljoin(base_url, prop_value)]
 
         # if element has one object child use data if exists and
@@ -118,7 +123,7 @@ def photo(el, base_url=''):
             poss_obj = poss_objs[0]
             if mf2_classes.root(poss_obj.get('class', [])) == []:
                 prop_value = get_attr(poss_obj, "data", check_name="object")
-                if prop_value:
+                if prop_value is not None:
                     return [prop_value]
 
 
@@ -134,7 +139,7 @@ def url(el, base_url=''):
     """
     # if element is a link use its href if exists
     prop_value = get_attr(el, "href", check_name=("a", "area"))
-    if prop_value:
+    if prop_value is not None:  # an empty href is valid
         return [urljoin(base_url, prop_value)]
 
     # if one link child use its href
@@ -143,5 +148,5 @@ def url(el, base_url=''):
         poss_a = poss_as[0]
         if mf2_classes.root(poss_a.get('class', [])) == []:
             prop_value = get_attr(poss_a, "href", check_name="a")
-            if prop_value:
+            if prop_value is not None:
                 return [urljoin(base_url, prop_value)]

--- a/mf2py/implied_properties.py
+++ b/mf2py/implied_properties.py
@@ -20,12 +20,12 @@ def name(el):
     """
     # if image use alt text if not empty
     prop_value = get_attr(el, "alt", check_name=("img", "area"))
-    if prop_value is not None:
+    if prop_value:
         return [prop_value]
 
     # if abbreviation use the title if not empty
     prop_value = get_attr(el, "title", check_name="abbr")
-    if prop_value is not None:
+    if prop_value:
         return [prop_value]
 
     # if only one child
@@ -33,12 +33,12 @@ def name(el):
     if len(children) == 1:
         # use alt if child is img
         prop_value = get_attr(children[0], "alt", check_name="img")
-        if prop_value is not None:
+        if prop_value:
             return [prop_value]
 
         # use title if child is abbr
         prop_value = get_attr(children[0], "title", check_name="abbr")
-        if prop_value is not None:
+        if prop_value:
             return [prop_value]
 
         grandchildren = list(get_children(children[0]))
@@ -46,12 +46,12 @@ def name(el):
         if len(grandchildren) == 1:
             # use alt if grandchild is img
             prop_value = get_attr(grandchildren[0], "alt", check_name="img")
-            if prop_value is not None:
+            if prop_value:
                 return [prop_value]
 
             # use title if grandchild is title
             prop_value = get_attr(grandchildren[0], "title", check_name="abbr")
-            if prop_value is not None:
+            if prop_value:
                 return [prop_value]
 
     # use text if all else fails
@@ -70,12 +70,12 @@ def photo(el, base_url=''):
     """
     # if element is an image use source if exists
     prop_value = get_attr(el, "src", check_name="img")
-    if prop_value is not None:
+    if prop_value:
         return [urljoin(base_url, prop_value)]
 
     # if element is an object use data if exists
     prop_value = get_attr(el, "data", check_name="object")
-    if prop_value is not None:
+    if prop_value:
         return [prop_value]
 
     # if element has one image child use source if exists and img is
@@ -85,7 +85,7 @@ def photo(el, base_url=''):
         poss_img = poss_imgs[0]
         if mf2_classes.root(poss_img.get('class', [])) == []:
             prop_value = get_attr(poss_img, "src", check_name="img")
-            if prop_value is not None:
+            if prop_value:
                 return [urljoin(base_url, prop_value)]
 
     # if element has one object child use data if exists and object is
@@ -95,7 +95,7 @@ def photo(el, base_url=''):
         poss_obj = poss_objs[0]
         if mf2_classes.root(poss_obj.get('class', [])) == []:
             prop_value = get_attr(poss_obj, "data", check_name="object")
-            if prop_value is not None:
+            if prop_value:
                 return [prop_value]
 
     children = list(get_children(el))
@@ -108,7 +108,7 @@ def photo(el, base_url=''):
             poss_img = poss_imgs[0]
             if mf2_classes.root(poss_img.get('class', [])) == []:
                 prop_value = get_attr(poss_img, "src", check_name="img")
-                if prop_value is not None:
+                if prop_value:
                     return [urljoin(base_url, prop_value)]
 
         # if element has one object child use data if exists and
@@ -118,7 +118,7 @@ def photo(el, base_url=''):
             poss_obj = poss_objs[0]
             if mf2_classes.root(poss_obj.get('class', [])) == []:
                 prop_value = get_attr(poss_obj, "data", check_name="object")
-                if prop_value is not None:
+                if prop_value:
                     return [prop_value]
 
 
@@ -134,7 +134,7 @@ def url(el, base_url=''):
     """
     # if element is a link use its href if exists
     prop_value = get_attr(el, "href", check_name=("a", "area"))
-    if prop_value is not None:
+    if prop_value:
         return [urljoin(base_url, prop_value)]
 
     # if one link child use its href
@@ -143,5 +143,5 @@ def url(el, base_url=''):
         poss_a = poss_as[0]
         if mf2_classes.root(poss_a.get('class', [])) == []:
             prop_value = get_attr(poss_a, "href", check_name="a")
-            if prop_value is not None:
+            if prop_value:
                 return [urljoin(base_url, prop_value)]

--- a/test/examples/implied_properties.html
+++ b/test/examples/implied_properties.html
@@ -6,13 +6,16 @@
 </head>
 <body>
 	<span class="h-card">Tom Morris</span>
-	
+
 	<a class="h-card" href="http://tommorris.org/">Tom Morris</a>
-	
+
 	<a class="h-card" href="http://tommorris.org/"><img src="http://tommorris.org/photo.png" alt="" />Tom Morris</a>
-	
+
 	<a class="h-card" href="http://tommorris.org/"><img src="http://tommorris.org/photo.png" alt="Tom Morris" /></a>
-	
+
 	<img class="h-card" src="http://tommorris.org/photo.png" alt="Tom Morris" />
+
+        <!-- Make sure "" is interpreted as a relative URL -->
+	<a class="h-card" href=""><img src="" />Tom Morris</a>
 </body>
 </html>

--- a/test/examples/silopub.html
+++ b/test/examples/silopub.html
@@ -1,0 +1,27 @@
+
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <link rel="authorization_endpoint" href="https://silo.pub/indieauth">
+        <link rel="token_endpoint" href="https://silo.pub/token">
+        <link rel="micropub" href="https://silo.pub/micropub">
+        <link rel="me" href="https://twitter.com/kylewmahan">
+        <link href="https://abs.twimg.com/favicons/favicon.ico" rel="shortcut icon">
+        <style>img { max-height: 4em; }</style>
+    </head>
+    <body>
+        Micropub proxy for
+        <div class="h-x-syndication-target">
+          <a class="p-user h-card" href="https://twitter.com/kylewmahan">
+            <img src="https://pbs.twimg.com/profile_images/641457114381074432/vUdKopH8_normal.jpg" alt="" />
+            @kylewmahan
+          </a>
+          on
+          <a class="p-service h-card" href="https://twitter.com/">
+            <img src="https://abs.twimg.com/favicons/favicon.ico" alt="" />
+            Twitter
+          </a>
+        </div>
+    </body>
+</html>

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -137,19 +137,26 @@ def test_plain_child_microformat():
 
 def test_implied_name():
     result = parse_fixture("implied_properties.html")
-    assert_equal(result["items"][0]["properties"]["name"][0], "Tom Morris")
+    for i in range(6):
+        assert_equal(result["items"][i]["properties"]["name"][0], "Tom Morris")
 
 
 def test_implied_url():
-    result = parse_fixture("implied_properties.html")
-    assert_equal(result["items"][1]["properties"]["url"][0],
-                 "http://tommorris.org/")
+    result = parse_fixture("implied_properties.html", url="http://foo.com/")
+    assert_equal(
+        result["items"][1]["properties"]["url"][0], "http://tommorris.org/")
+    # img should not have a "url" property
+    assert_true("url" not in result["items"][4]["properties"])
+    # href="" is relative to the base url
+    assert_equal(result["items"][5]["properties"]["url"][0], "http://foo.com/")
 
 
 def test_implied_nested_photo():
-    result = parse_fixture("implied_properties.html")
+    result = parse_fixture("implied_properties.html", url="http://bar.org")
     assert_equal(result["items"][2]["properties"]["photo"][0],
                  "http://tommorris.org/photo.png")
+    # src="" is relative to the base url
+    assert_equal(result["items"][5]["properties"]["photo"][0], "http://bar.org")
 
 
 def test_implied_nested_photo_alt_name():


### PR DESCRIPTION
Based on discussion in http://microformats.org/wiki/microformats2-parsing-issues#implied_name_when_alt.3D.22.22
the implied cases that expect alt or title should ignore it when it's intentionally blank.

Fixes #67