### PR TITLE
Add backcompat for wordpress, blogger

### DIFF
--- a/mf2py/backcompat.py
+++ b/mf2py/backcompat.py
@@ -64,7 +64,14 @@ CLASSIC_PROPERTY_MAP = {
         'organization-name': ['p-organization-name'],
         'organization-unit': ['p-organization-unit'],
     },
-    'hentry': {
+    'hfeed': {
+        'title': ['p-name'], #for blogger, if they move hfeed to the right place
+        'description': ['p-summary'],  #for blogger, if they move hfeed to the right place
+        'site-title': ['p-name'], #for wordpress defaults
+        'site-description': ['p-summary'],  #for wordpress defaults
+        'category': ['p-category'],
+    },
+        'hentry': {
         'entry-title': ['p-name'],
         'entry-summary': ['p-summary'],
         'entry-content': ['e-content'],

--- a/mf2py/backcompat.py
+++ b/mf2py/backcompat.py
@@ -71,7 +71,7 @@ CLASSIC_PROPERTY_MAP = {
         'site-description': ['p-summary'],  #for wordpress defaults
         'category': ['p-category'],
     },
-        'hentry': {
+    'hentry': {
         'entry-title': ['p-name'],
         'entry-summary': ['p-summary'],
         'entry-content': ['e-content'],

--- a/mf2py/parser.py
+++ b/mf2py/parser.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals, print_function
 
 import json
 from bs4 import BeautifulSoup
+from bs4 import UnicodeDammit
 
 import requests
 
@@ -20,6 +21,10 @@ if sys.version < '3':
     from urlparse import urlparse, urljoin
 else:
     from urllib.parse import urlparse, urljoin
+
+def unmung(s):
+    return UnicodeDammit(s,["utf-8","windows-1252"]).unicode_markup
+    
 
 
 def parse(doc=None, url=None):
@@ -126,29 +131,28 @@ class Parser(object):
 
             # if some properties not already found find in implied ways
             if "name" not in properties:
-                properties["name"] = implied_properties.name(el)
-
+                properties["name"] = [unmung(prop) for prop in implied_properties.name(el)]
             if "photo" not in properties:
                 x = implied_properties.photo(el, base_url=self.__url__)
                 if x is not None:
-                    properties["photo"] = x
+                    properties["photo"] = [unmung(u) for u in x]
 
             if "url" not in properties:
                 x = implied_properties.url(el, base_url=self.__url__)
                 if x is not None:
-                    properties["url"] = x
+                    properties["url"] = [unmung(u) for u in x]
 
             # build microformat with type and properties
-            microformat = {"type": root_class_names,
+            microformat = {"type": [unmung(class_name) for class_name in root_class_names],
                            "properties": properties}
             if str(el.name) == "area":
                 shape = get_attr(el, 'shape')
                 if shape is not None:
-                    microformat['shape'] = shape
+                    microformat['shape'] = unmung(shape)
 
                 coords = get_attr(el, 'coords')
                 if coords is not None:
-                    microformat['coords'] = coords
+                    microformat['coords'] = unmung(coords)
 
             # insert children if any
             if children:
@@ -163,7 +167,7 @@ class Parser(object):
                     # details: https://github.com/tommorris/mf2py/issues/35
                     microformat.update(simple_value)
                 else:
-                    microformat["value"] = simple_value
+                    microformat["value"] = unmung(simple_value)
 
             return microformat
 
@@ -187,7 +191,7 @@ class Parser(object):
 
                 # if value has not been parsed then parse it
                 if p_value is None:
-                    p_value = parse_property.text(el).strip()
+                    p_value = unmung(parse_property.text(el).strip())
 
                 if root_class_names:
                     prop_value.append(handle_microformat(
@@ -211,7 +215,7 @@ class Parser(object):
                         root_class_names, el, value_property="url",
                         simple_value=u_value))
                 else:
-                    prop_value.append(u_value)
+                    prop_value.append(unmung(u_value))
 
             # Parse datetime dt-* properties.
             dt_value = None
@@ -229,9 +233,10 @@ class Parser(object):
 
                 if root_class_names:
                     prop_value.append(handle_microformat(
-                        root_class_names, el, simple_value=dt_value))
+                        root_class_names, el, simple_value=unmung(dt_value)))
                 else:
-                    prop_value.append(dt_value)
+                    if dt_value is not None:
+                        prop_value.append(unmung(dt_value))
 
             # Parse embedded markup e-* properties.
             e_value = None
@@ -269,11 +274,11 @@ class Parser(object):
         def parse_rels(el):
             """Parse an element for rel microformats
             """
-            rel_attrs = get_attr(el, 'rel')
+            rel_attrs = [unmung(rel) for rel in get_attr(el, 'rel')]
             # if rel attributes exist
             if rel_attrs is not None:
                 # find the url and normalise it
-                url = urljoin(self.__url__, el.get('href', ''))
+                url = unmung(urljoin(self.__url__, el.get('href', '')))
                 value_dict = self.__parsed__["rel-urls"].get(url, {})
                 if "text" not in value_dict:
                     value_dict["text"] = el.get_text().strip() #first one wins
@@ -282,7 +287,7 @@ class Parser(object):
                 for knownattr in ("media","hreflang","type","title"):
                     x = get_attr(el, knownattr)
                     if x is not None:
-                        value_dict[knownattr] = x
+                        value_dict[knownattr] = unmung(x)
                 self.__parsed__["rel-urls"][url] = value_dict
                 for rel_value in rel_attrs:
                     value_list = self.__parsed__["rels"].get(rel_value, [])
@@ -299,11 +304,11 @@ class Parser(object):
                         [r for r in rel_attrs if not r == "alternate"])
                     if x is not "":
                         alternate_dict["rel"] = x
-                    alternate_dict["text"] = el.get_text().strip()
+                    alternate_dict["text"] = unmung(el.get_text().strip())
                     for knownattr in ("media", "hreflang", "type", "title"):
                         x = get_attr(el, knownattr)
                         if x is not None:
-                            alternate_dict[knownattr] = x
+                            alternate_dict[knownattr] = unmung(x)
                     alternate_list.append(alternate_dict)
                     self.__parsed__["alternates"] = alternate_list
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -420,7 +420,9 @@ def test_mf2tests():
     for jsonfile in allfiles:
         htmlfile = jsonfile[:-4]+'html'
         with open(htmlfile) as f:
-            p = json.loads(Parser(doc=f).to_json())
+            parsed=Parser(doc=f)
+            p = json.loads(parsed.to_json())
+            yield check_unicode, htmlfile, parsed.to_dict()
         with open(jsonfile) as jsonf:
             try:
                 s = json.load(jsonf)


### PR DESCRIPTION
Wordpress has site-title and site-description on the default templates, so this will fix hfeed parsing from them at once.
Blogger has title and description, but the hfeed is often misplaced so doesn't contain them. This may be a small fix to default templates.

Example at http://www.unmung.com/mf2?url=http%3A%2F%2Fma.tt&html=&pretty=on

Shows now getting a name a summary tagline from matt's bloge, where before we had a nasty implied name.
